### PR TITLE
TableDumpV2PeerIndexTableEntry fixes

### DIFF
--- a/BGPDump.py
+++ b/BGPDump.py
@@ -208,7 +208,12 @@ class TableDumpV2PeerIndexTableEntry:
 
     @property
     def peerIP(self):
-        return self.entry.peer_ip
+
+        if self.afi == AF_INET:
+            return inet_ntop(AF_INET, self.bgp.ffi.buffer(self.bgp.ffi.addressof(self.entry.peer_ip.v4_addr))[:])
+
+        if self.afi == AF_INET6:
+            return inet_ntop(AF_INET6, self.bgp.ffi.buffer(self.bgp.ffi.addressof(self.entry.peer_ip.v6_addr))[:])
 
     @property
     def peerRouterID(self):

--- a/BGPDump.py
+++ b/BGPDump.py
@@ -217,7 +217,7 @@ class TableDumpV2PeerIndexTableEntry:
 
     @property
     def peerRouterID(self):
-        return self.entry.peer_bgp_id
+        return inet_ntop(AF_INET, self.bgp.ffi.buffer(self.bgp.ffi.addressof(self.entry.peer_bgp_id))[:])
 
     @property
     def peerAS(self):


### PR DESCRIPTION
 * Make `TableDumpV2PeerIndexTableEntry.peerIP` return a string instead of a `struct in_addr`
 * Make `TableDumpV2PeerIndexTableEntry.peerIRouterID` return a string instead of a `struct in_addr`